### PR TITLE
Add manifest.json for HACS compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ hf-15-*.json
 .DS_Store
 Thumbs.db
 *.json
+!custom_components/xbloom_mqtt/manifest.json
 internal_notes/*
 resources/*
 sources/*

--- a/custom_components/xbloom_mqtt/manifest.json
+++ b/custom_components/xbloom_mqtt/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "xbloom_mqtt",
+  "name": "XBloom MQTT",
+  "codeowners": ["@fhenwood"],
+  "config_flow": true,
+  "dependencies": ["mqtt"],
+  "documentation": "https://github.com/fhenwood/PyBloom",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/fhenwood/PyBloom/issues",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
Fixes #1 - HACS requires a manifest.json at
custom_components/xbloom_mqtt/manifest.json to register the
integration as a custom repository. Also added a .gitignore
exception for this file since *.json is globally ignored.

https://claude.ai/code/session_01Va1qzWqKcEKHXjbXnfWnMV